### PR TITLE
Fix imports for tests

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,12 @@
-# Empty initialization file to prevent pylint errors when scanning root directory
+# Ensure the project modules in the ``src`` directory are importable when the
+# package is used without being installed.  The tests import ``dev_monitor`` and
+# ``project_watch`` directly, so the ``src`` directory needs to be on
+# ``sys.path``.
+from pathlib import Path
+import sys
+
+# Compute the absolute path to the ``src`` directory relative to this file and
+# add it to ``sys.path`` if it is not already present.
+SRC_PATH = str(Path(__file__).resolve().parent / "src")
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)

--- a/dev_monitor/__init__.py
+++ b/dev_monitor/__init__.py
@@ -1,0 +1,25 @@
+"""Thin wrapper to expose the implementation in ``src/dev_monitor``.
+
+The test suite imports ``dev_monitor`` directly. When the package has not been
+installed this small shim adjusts ``sys.path`` so that modules under the
+``src`` layout can be resolved transparently.
+"""
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+SRC_PATH = Path(__file__).resolve().parent.parent / "src" / "dev_monitor"
+if str(SRC_PATH.parent) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH.parent))
+
+_spec = spec_from_file_location("dev_monitor_real", SRC_PATH / "__init__.py")
+_module = module_from_spec(_spec)
+_spec.loader.exec_module(_module)  # type: ignore
+
+__all__ = getattr(_module, "__all__", [])
+__doc__ = _module.__doc__
+__path__ = [str(SRC_PATH)]
+
+for name, value in _module.__dict__.items():
+    if not name.startswith("_"):
+        globals()[name] = value

--- a/project_watch/__init__.py
+++ b/project_watch/__init__.py
@@ -1,0 +1,20 @@
+"""Thin wrapper to expose ``src/project_watch`` during testing."""
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+SRC_PATH = Path(__file__).resolve().parent.parent / "src" / "project_watch"
+if str(SRC_PATH.parent) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH.parent))
+
+_spec = spec_from_file_location("project_watch_real", SRC_PATH / "__init__.py")
+_module = module_from_spec(_spec)
+_spec.loader.exec_module(_module)  # type: ignore
+
+__all__ = getattr(_module, "__all__", [])
+__doc__ = _module.__doc__
+__path__ = [str(SRC_PATH)]
+
+for name, value in _module.__dict__.items():
+    if not name.startswith("_"):
+        globals()[name] = value

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+import sys
+SRC = Path(__file__).resolve().parent / 'src'
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/src/dev_monitor/cli.py
+++ b/src/dev_monitor/cli.py
@@ -1,15 +1,23 @@
 """Command-line interface for dev_monitor."""
 import argparse
+import sys
 from .monitor import DevMonitor
 
-def parse_args():
+def parse_args(args=None):
+    """Parse command line arguments.
+
+    When *args* is ``None`` an empty list is used so that pytest's own command
+    line options do not interfere during testing.  The :func:`main` function
+    passes ``sys.argv[1:]`` to parse the real command line when executed as a
+    script.
+    """
     parser = argparse.ArgumentParser(description="Development Environment Monitor")
     parser.add_argument("--log-dir", default="logs", help="Log directory")
     parser.add_argument("--interval", type=int, default=1, help="Update interval (seconds) [default: 1]")
     parser.add_argument("--sections", nargs="+", default=["docker", "pytest", "pylint"],
                         choices=["docker", "pytest", "pylint"],
                         help="Sections to monitor [default: all]")
-    return parser.parse_args()
+    return parser.parse_args([] if args is None else args)
 
 def print_startup_message(args):
     """Print startup message with configuration details."""
@@ -19,7 +27,7 @@ def print_startup_message(args):
     print("Press Ctrl+C to exit...")
 
 def main():
-    args = parse_args()
+    args = parse_args(sys.argv[1:])
     monitor = DevMonitor(
         log_dir=args.log_dir,
         interval=args.interval

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+SRC_DIR = ROOT_DIR / 'src'
+for path in (str(ROOT_DIR), str(SRC_DIR)):
+    if path not in sys.path:
+        sys.path.insert(0, path)


### PR DESCRIPTION
## Summary
- expose src modules for tests via shim packages
- add CLI parsing improvements
- ensure pytest discovers packages using conftest hooks

## Testing
- `pytest tests/test_cli.py::test_parse_args_defaults -q`

------
https://chatgpt.com/codex/tasks/task_e_684af3f0406883229d1b14edf8a8f28b